### PR TITLE
Basic Notebook CSS overrides

### DIFF
--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -5,3 +5,17 @@ mainly to be overridden in profile/static/custom/custom.css
 
 This will always be an empty file in IPython
 */
+
+#header-container {
+  display: none;
+}
+
+#menubar-container {
+  width: auto;
+  margin-left: 20px;
+}
+
+#notebook .container {
+  width: auto;
+  margin: 0 20px 20px 23px;
+}


### PR DESCRIPTION
# Summary

Modifies the notebook styles:
- hide the header
- disable the max width on the containers
# Reviewers

@jpang-h4 @supreeth-t 
