### PR TITLE
Notebook - hide incompatible menu items

### DIFF
--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -83,3 +83,17 @@ body > #header .header-bar {
   position: relative;
   top: 19px;
 }
+
+/* Hide menu items that don't work with our integration */
+#new_notebook,
+#open_notebook,
+#copy_notebook,
+#rename_notebook,
+#save_checkpoint,
+#restore_checkpoint,
+#trust_notebook,
+#kill_and_exit,
+#toggle_header,
+#file_menu .divider {
+  display: none;
+}


### PR DESCRIPTION
# Summary

A few of the menu items don't play well or make sense with our iframe'd notebook in the context of Lab. this hides those menu items.
# Review

@jpang-h4 @supreeth-t 
