### PR TITLE
Hide Download Menu, except for HTML option

### DIFF
--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -73,6 +73,10 @@ body > #header .header-bar {
   display: none;
 }
 
+li#download_ipynb, li#download_pdf, li#download_markdown, li#download_script, li#download_rst {
+  display: none;
+}
+
 #kernel_indicator {
   zposition: absolute;
   zright: 0;


### PR DESCRIPTION
Summary:
- Hide download menu, except for HTML option

Screenshot:
![screen shot 2017-03-13 at 7 39 00 pm](https://cloud.githubusercontent.com/assets/205067/23883775/75dadfa4-0826-11e7-822f-90394f98552e.png)


Tests Implemented:
- Visual

QA:
-

Reviewers:
@duaneatat @supreeth-t @jpang-h4 

Subscribers:
@jpang-h4 @oshokut 