### PR TITLE
Display script in export menu

### DIFF
--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -73,7 +73,7 @@ body > #header .header-bar {
   display: none;
 }
 
-li#download_ipynb, li#download_pdf, li#download_markdown, li#download_script, li#download_rst {
+li#download_ipynb, li#download_pdf, li#download_markdown, li#download_rst {
   display: none;
 }
 

--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -73,6 +73,10 @@ body > #header .header-bar {
   display: none;
 }
 
+li#download_ipynb, li#download_pdf, li#download_markdown, li#download_script, li#download_rst {
+  display: none;
+}
+
 #kernel_indicator {
   zposition: absolute;
   zright: 0;


### PR DESCRIPTION
Summary:
- Display script in export menu, which is applicable for both Python and Scala

Screenshot:
- Updated menu
![screen shot 2017-03-21 at 2 27 31 pm](https://cloud.githubusercontent.com/assets/205067/24171668/96c00a88-0e42-11e7-91fc-28f4ea75b488.png)


Tests Implemented:
- Visual

QA:
-

Reviewers:
@jpang-h4 

Subscribers:
@jpang-h4 @oshokut @supreeth-t 